### PR TITLE
feat(main): add support for updating CSRF token from header

### DIFF
--- a/lib/utils/api.ts
+++ b/lib/utils/api.ts
@@ -24,6 +24,10 @@ export default class Api extends AxiosWrapper {
                 const {config} = error;
 
                 if (config && !config[csrfRetryKey] && error.response?.status === 419) {
+                    if (error.response.headers['x-csrf-token']) {
+                        this.setCSRFToken(error.response.headers['x-csrf-token']);
+                    }
+
                     return this._axios({
                         ...config,
                         [csrfRetryKey]: true,


### PR DESCRIPTION
Support for X-CSRF-Token header is already exists in Axios-Wrapper here:
https://github.com/gravity-ui/axios-wrapper/blob/main/src/index.ts#L58

In this PR we add checking for CSRF token header in response and applying it to Axios-Wrapper settings when we receive a CSRF token error from the server.
