### PR TITLE
chore: tune release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,19 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release/v*
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: gravity-ui/release-action@v1
-      with:
-        github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
-        npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
-        node-version: 18
+      - name: Release from ${{ github.ref_name }}
+        uses: gravity-ui/release-action@v1
+        with:
+          github-token: ${{ secrets.GRAVITY_UI_BOT_GITHUB_TOKEN }}
+          npm-token: ${{ secrets.GRAVITY_UI_BOT_NPM_TOKEN }}
+          node-version: 18
+          default-branch: ${{ github.ref_name != 'main' && github.ref_name || null }}
+          npm-dist-tag: ${{ github.ref_name != 'main' && 'untagged' || 'latest' }}


### PR DESCRIPTION
Add ability to run release not only from `main` branch