### PR TITLE
feat: added the ability to connect request interceptors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,9 +9,9 @@ import type {AxiosRequestConfig} from 'axios';
 import {CancellablePromise} from './CancellablePromise';
 import {Lang} from './constants';
 import Api, {createScopeServicePath} from './utils/api';
-import type {RequestResponseInterceptors} from './utils/api';
+import type {AxiosInterceptors} from './utils/api';
 
-export type {RequestResponseInterceptors} from './utils/api';
+export type {AxiosInterceptors} from './utils/api';
 
 export interface SdkActionOptions {
     concurrentId?: string;
@@ -29,7 +29,7 @@ export interface SdkActionFunc<TRequestData, TResponseData> {
 export type ScopeServiceQueryInterceptors = {
     scope?: string;
     service: string;
-    interceptors: RequestResponseInterceptors | RequestResponseInterceptors[];
+    interceptors: AxiosInterceptors | AxiosInterceptors[];
 };
 
 export interface SdkConfig {
@@ -50,7 +50,7 @@ export interface SdkConfig {
         service?: string,
         action?: string,
     ) => SdkActionFunc<TRequestData, TResponseData>;
-    queriesInterceptors?: ScopeServiceQueryInterceptors[];
+    axiosInterceptors?: ScopeServiceQueryInterceptors[];
 }
 
 export const generateConcurrentId = (() => {
@@ -180,8 +180,8 @@ export default function sdkFactory<TSchema extends SchemasByScope>(config?: SdkC
     const endpoint = sdkConfig.endpoint || DEFAULT_ENDPOINT;
     const decorator = sdkConfig.decorator || DEFAULT_DECORATOR;
 
-    const queriesInterceptors = sdkConfig.queriesInterceptors
-        ? sdkConfig.queriesInterceptors.reduce((result, item) => {
+    const axiosInterceptors = sdkConfig.axiosInterceptors
+        ? sdkConfig.axiosInterceptors.reduce((result, item) => {
               const path = createScopeServicePath(item.service, item.scope);
               const interceptors = Array.isArray(item.interceptors)
                   ? item.interceptors
@@ -193,13 +193,13 @@ export default function sdkFactory<TSchema extends SchemasByScope>(config?: SdkC
               result[path].push(...interceptors);
 
               return result;
-          }, {} as Record<string, RequestResponseInterceptors[]>)
+          }, {} as Record<string, AxiosInterceptors[]>)
         : undefined;
 
     const api = new Api(
         {
             updateCsrfEnabled: sdkConfig.updateCsrfEnabled,
-            queriesInterceptors,
+            axiosInterceptors,
             config: axiosConfig,
         },
         sdkConfig?.handleRequestError,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,10 @@ import type {AxiosRequestConfig} from 'axios';
 
 import {CancellablePromise} from './CancellablePromise';
 import {Lang} from './constants';
-import Api from './utils/api';
+import Api, {createScopeServicePath} from './utils/api';
+import type {RequestResponseInterceptors} from './utils/api';
+
+export type {RequestResponseInterceptors} from './utils/api';
 
 export interface SdkActionOptions {
     concurrentId?: string;
@@ -22,6 +25,12 @@ export interface SdkActionOptions {
 export interface SdkActionFunc<TRequestData, TResponseData> {
     (data: TRequestData, options?: SdkActionOptions): CancellablePromise<TResponseData>;
 }
+
+export type ScopeServiceQueryInterceptors = {
+    scope?: string;
+    service: string;
+    interceptors: RequestResponseInterceptors | RequestResponseInterceptors[];
+};
 
 export interface SdkConfig {
     axiosConfig?: AxiosRequestConfig;
@@ -41,6 +50,7 @@ export interface SdkConfig {
         service?: string,
         action?: string,
     ) => SdkActionFunc<TRequestData, TResponseData>;
+    queriesInterceptors?: ScopeServiceQueryInterceptors[];
 }
 
 export const generateConcurrentId = (() => {
@@ -170,9 +180,26 @@ export default function sdkFactory<TSchema extends SchemasByScope>(config?: SdkC
     const endpoint = sdkConfig.endpoint || DEFAULT_ENDPOINT;
     const decorator = sdkConfig.decorator || DEFAULT_DECORATOR;
 
+    const queriesInterceptors = sdkConfig.queriesInterceptors
+        ? sdkConfig.queriesInterceptors.reduce((result, item) => {
+              const path = createScopeServicePath(item.service, item.scope);
+              const interceptors = Array.isArray(item.interceptors)
+                  ? item.interceptors
+                  : [item.interceptors];
+
+              if (!result[path]) {
+                  result[path] = [];
+              }
+              result[path].push(...interceptors);
+
+              return result;
+          }, {} as Record<string, RequestResponseInterceptors[]>)
+        : undefined;
+
     const api = new Api(
         {
             updateCsrfEnabled: sdkConfig.updateCsrfEnabled,
+            queriesInterceptors,
             config: axiosConfig,
         },
         sdkConfig?.handleRequestError,

--- a/lib/utils/api.ts
+++ b/lib/utils/api.ts
@@ -8,37 +8,144 @@ import {parseError} from './common';
 // Symbols are not preserved in the Axios config
 const csrfRetryKey = '__ CSRF retry';
 
+const urlRegexp = /\/(?<api>\w+)\/(?<scope>\w+)\/(?<service>\w+)\/(?<action>\w+)/i;
+
+export interface RequestResponseInterceptors {
+    requestInterceptorSuccess?: (config: any) => Promise<any>;
+    requestInterceptorError?: (error: any) => Promise<any>;
+    responseInterceptorSuccess?: (data: any) => Promise<any>;
+    responseInterceptorError?: (error: any) => Promise<any>;
+}
+
+type QueriesInterceptors = Record<string, RequestResponseInterceptors[]>;
+
 export type ApiOptions = AxiosWrapperOptions & {
     updateCsrfEnabled?: boolean;
+    queriesInterceptors?: QueriesInterceptors;
 };
+
+export function createScopeServicePath(service: string, scope?: string): string {
+    return `${scope ?? 'root'}/${service}`;
+}
+
+export function getScopeServicePath(url: string): string {
+    const groups = url.match(urlRegexp)?.groups;
+
+    return groups ? createScopeServicePath(groups.service, groups.scope) : '';
+}
+
+type InterceptorsChainParams = {
+    url?: string;
+    queriesInterceptors?: QueriesInterceptors;
+    queryData: any;
+    success: boolean;
+    interceptorSelector: (
+        interceptors: RequestResponseInterceptors,
+    ) => ((data: any) => Promise<any>) | undefined;
+};
+
+export function makeInterceptorsChain({
+    url,
+    queriesInterceptors,
+    queryData,
+    success,
+    interceptorSelector,
+}: InterceptorsChainParams): Promise<any> {
+    let result: Promise<any> = success ? Promise.resolve(queryData) : Promise.reject(queryData);
+
+    if (!url) {
+        return result;
+    }
+
+    const path = getScopeServicePath(url);
+
+    for (const interceptors of queriesInterceptors?.[path] || []) {
+        const interceptor = interceptorSelector(interceptors);
+
+        if (interceptor) {
+            result = success
+                ? result.then(async (data) => await interceptor(data))
+                : result.catch(async (data) => await interceptor(data));
+        }
+    }
+
+    return result;
+}
 
 export default class Api extends AxiosWrapper {
     constructor(
-        {updateCsrfEnabled, ...props}: ApiOptions = {},
+        {updateCsrfEnabled, queriesInterceptors, ...props}: ApiOptions = {},
         handleRequestError?: (error: unknown) => any,
     ) {
         super(props);
 
-        if (updateCsrfEnabled) {
-            this._axios.interceptors.response.use(null, async (error) => {
-                const {config} = error;
+        const requestSuccess = (config: any) => {
+            return makeInterceptorsChain({
+                url: config?.url,
+                queriesInterceptors,
+                queryData: config,
+                success: true,
+                interceptorSelector: (interceptors) => interceptors.requestInterceptorSuccess,
+            });
+        };
 
-                if (config && !config[csrfRetryKey] && error.response?.status === 419) {
-                    const csrfHeaderName = (this.csrfHeaderName || 'x-csrf-token').toLowerCase();
+        const requestError = (error: any) => {
+            return makeInterceptorsChain({
+                url: error?.config?.url,
+                queriesInterceptors,
+                queryData: error,
+                success: false,
+                interceptorSelector: (interceptors) => interceptors.requestInterceptorError,
+            });
+        };
 
-                    if (error.response.headers[csrfHeaderName]) {
-                        this.setCSRFToken(error.response.headers[csrfHeaderName]);
+        const responseSuccess = (data: any) => {
+            return makeInterceptorsChain({
+                url: data?.config?.url,
+                queriesInterceptors,
+                queryData: data,
+                success: true,
+                interceptorSelector: (interceptors) => interceptors.responseInterceptorSuccess,
+            });
+        };
+
+        const responseError = (error: any) => {
+            let result: Promise<any> = makeInterceptorsChain({
+                url: error?.config?.url,
+                queriesInterceptors,
+                queryData: error,
+                success: false,
+                interceptorSelector: (interceptors) => interceptors.responseInterceptorError,
+            });
+
+            if (updateCsrfEnabled) {
+                result = result.catch(async (error) => {
+                    const {config} = error;
+
+                    if (config && !config[csrfRetryKey] && error.response?.status === 419) {
+                        const csrfHeaderName = (
+                            this.csrfHeaderName || 'x-csrf-token'
+                        ).toLowerCase();
+
+                        if (error.response.headers[csrfHeaderName]) {
+                            this.setCSRFToken(error.response.headers[csrfHeaderName]);
+                        }
+
+                        return this._axios({
+                            ...config,
+                            [csrfRetryKey]: true,
+                        });
                     }
 
-                    return this._axios({
-                        ...config,
-                        [csrfRetryKey]: true,
-                    });
-                }
+                    return Promise.reject(error);
+                });
+            }
 
-                return Promise.reject(error);
-            });
-        }
+            return result;
+        };
+
+        this._axios.interceptors.request.use(requestSuccess, requestError);
+        this._axios.interceptors.response.use(responseSuccess, responseError);
 
         axiosRetry(this._axios, {
             retries: 0,


### PR DESCRIPTION
I want to add the ability to connect request interceptors that can perform certain actions before performing standard request processing.

Now, using this mechanism, we plan to connect handlers for different types of authentication, which, if there are certain cookies in the response, will trigger actions in the background to update the user's authorization cookies.