### PR TITLE
feat: add function for checking ACCOUNT_CHANGED and SESSION_EXPIRED codes

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,3 +2,9 @@ export enum Lang {
     Ru = 'ru',
     En = 'en',
 }
+
+export enum ErrorCode {
+    AccountChanged = 'ACCOUNT_CHANGED',
+    SessionExpired = 'SESSION_EXPIRED',
+    SDKRequestError = 'SDK_REQUEST_ERROR',
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,10 @@ import type {AxiosInterceptors} from './utils/api';
 
 export type {AxiosInterceptors} from './utils/api';
 
+export {isNeedResetError} from './utils/common';
+
+export {ErrorCode} from './constants';
+
 export interface SdkActionOptions {
     concurrentId?: string;
     collectRequest?: boolean;

--- a/lib/utils/common.ts
+++ b/lib/utils/common.ts
@@ -1,5 +1,6 @@
 import _get from 'lodash/get';
 
+import {ErrorCode} from '../constants';
 import type {GatewayError} from '../models/common';
 
 export function parseError(errorResponse: unknown) {
@@ -11,7 +12,7 @@ export function parseError(errorResponse: unknown) {
         if (typeof errorData === 'string') {
             parsedError = {
                 status: _get(errorResponse, 'status', 500),
-                code: 'SDK_REQUEST_ERROR',
+                code: ErrorCode.SDKRequestError,
                 message: 'SDK request error',
                 details: {
                     title: _get(errorResponse, 'status'),
@@ -21,7 +22,7 @@ export function parseError(errorResponse: unknown) {
         } else {
             parsedError = {
                 status: _get(errorData, 'status', 500),
-                code: _get(errorData, 'code', 'SDK_REQUEST_ERROR'),
+                code: _get(errorData, 'code', ErrorCode.SDKRequestError),
                 message: _get(errorData, 'message', 'SDK request error'),
                 details: _get(errorData, 'details'),
                 debug: _get(errorData, 'debug'),
@@ -30,11 +31,19 @@ export function parseError(errorResponse: unknown) {
     } else {
         parsedError = {
             status: 500,
-            code: 'SDK_REQUEST_ERROR',
+            code: ErrorCode.SDKRequestError,
             message: 'SDK request error',
             details: errorResponse as any,
         };
     }
 
     return parsedError;
+}
+
+export function isNeedResetError(
+    errorResponse: unknown,
+): errorResponse is {data: {code: ErrorCode.AccountChanged | ErrorCode.AccountChanged}} {
+    const code = _get(errorResponse, 'data.code');
+
+    return code === ErrorCode.AccountChanged || code === ErrorCode.SessionExpired;
 }


### PR DESCRIPTION
Adds `isNeedResetError` function that detects when backend returns ACCOUNT_CHANGED or SESSION_EXPIRED error codes, indicating that session refresh is required.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru