### PR TITLE
fix: correct return type annotation in isNeedResetError

### DIFF
--- a/lib/utils/common.ts
+++ b/lib/utils/common.ts
@@ -42,7 +42,7 @@ export function parseError(errorResponse: unknown) {
 
 export function isNeedResetError(
     errorResponse: unknown,
-): errorResponse is {data: {code: ErrorCode.AccountChanged | ErrorCode.AccountChanged}} {
+): errorResponse is {data: {code: ErrorCode.AccountChanged | ErrorCode.SessionExpired}} {
     const code = _get(errorResponse, 'data.code');
 
     return code === ErrorCode.AccountChanged || code === ErrorCode.SessionExpired;


### PR DESCRIPTION
Fix `isNeedResetError` return type annotation: replace duplicate `ErrorCode.AccountChanged` with correct `ErrorCode.SessionExpired`

## Summary by Sourcery

Bug Fixes:
- Correct the isNeedResetError return type annotation to include ErrorCode.SessionExpired instead of a duplicated ErrorCode.AccountChanged.